### PR TITLE
feat: build the count for channels and contacts with total count on top

### DIFF
--- a/src/app/features/workspace/components/base-chat-interface-component/base-chat-interface-component.ts
+++ b/src/app/features/workspace/components/base-chat-interface-component/base-chat-interface-component.ts
@@ -146,6 +146,7 @@ export abstract class BaseChatInterfaceComponent implements OnInit, OnDestroy {
     const messageData = {
       text: messageText,
       timestamp: serverTimestamp(),
+      sortAt: Timestamp.now(),
       authorId: this.currentUserId,
       authorAvatar: this.currentUserAvatar,
       authorName: this.currentUserDisplayName,

--- a/src/app/features/workspace/components/channel-interface-content/channel-interface-content.ts
+++ b/src/app/features/workspace/components/channel-interface-content/channel-interface-content.ts
@@ -15,6 +15,7 @@ import { ChannelMember } from '../../../../shared/components/channel-show-member
 import { DialogIconAddMemberToChannel } from '../../../../shared/components/dialog-icon-add-member-to-channel/dialog-icon-add-member-to-channel';
 import { take } from 'rxjs/operators';
 import { AddableUser } from '../../../../shared/components/dialog-icon-add-member-to-channel/dialog-icon-add-member-to-channel';
+import { ReadStateService } from '../../../../../services/read-state.service';
 
 @Component({
   selector: 'app-channel-interface-content',
@@ -30,8 +31,8 @@ export class ChannelInterfaceContent extends BaseChatInterfaceComponent {
   private loadedProfileIds = new Set<string>();
   private localMessagesSub?: any;
 
-  members$!: Observable<ChannelMember[]>; // für den Dialog
-  avatarPreview$!: Observable<ChannelMember[]>; // erste 3 fürs Badge
+  members$!: Observable<ChannelMember[]>;
+  avatarPreview$!: Observable<ChannelMember[]>; 
   memberCount$!: Observable<number>;
 
   constructor(
@@ -40,7 +41,8 @@ export class ChannelInterfaceContent extends BaseChatInterfaceComponent {
     protected override authService: AuthService,
     private channelService: ChannelService,
     private userService: UserService,
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    private read: ReadStateService
   ) {
     super(route, firestore, authService);
   }
@@ -88,7 +90,22 @@ export class ChannelInterfaceContent extends BaseChatInterfaceComponent {
       },
       error: (err) => console.error('Error fetching channel data:', err),
     });
+    if (this.currentUserId) {
+      this.read.markChannelRead(chatId, this.currentUserId);
+    } else {
+      this.authService.currentUser$.pipe(take(1)).subscribe((u) => {
+        if (u?.uid) this.read.markChannelRead(chatId, u.uid);
+      });
+    }
   }
+
+  override async handleNewMessage(text: string) {
+  if (this.chatId) this.read.bumpLastChannelMessage(this.chatId); // ⬅️ NEU: Optimistischer bump
+  await super.handleNewMessage(text);
+  if (this.chatId && this.currentUserId) {
+    await this.read.markChannelRead(this.chatId, this.currentUserId); // ⬅️ NEU
+  }
+}
 
   /**
    * Preload user profiles for given member IDs:
@@ -147,42 +164,42 @@ export class ChannelInterfaceContent extends BaseChatInterfaceComponent {
     this.memberCount$ = this.members$.pipe(map((ms) => ms.length));
   }
 
-  // Öffnet ChannelShowMembersDialog //
+  // open ChannelShowMembersDialog //
   openMembersDialog(ev?: MouseEvent, anchor?: HTMLElement) {
-  ev?.stopPropagation();
+    ev?.stopPropagation();
 
-  const el = anchor ?? (ev?.currentTarget as HTMLElement);
-  const rect = el.getBoundingClientRect();
+    const el = anchor ?? (ev?.currentTarget as HTMLElement);
+    const rect = el.getBoundingClientRect();
 
-  const GAP = 5;
-  const DLG_W = 450;
-  const top  = rect.bottom + window.scrollY + GAP;
-  const left = Math.max(8, rect.right + window.scrollX - DLG_W);
+    const GAP = 5;
+    const DLG_W = 450;
+    const top = rect.bottom + window.scrollY + GAP;
+    const left = Math.max(8, rect.right + window.scrollX - DLG_W);
 
-  const ref = this.dialog.open(ChannelShowMembersDialog, {
-    width: `${DLG_W}px`,
-    height: '411px',
-    autoFocus: false,
-    hasBackdrop: true,
-    panelClass: 'members-dialog-panel',
-    position: { top: `${top}px`, left: `${left}px` },
-  });
+    const ref = this.dialog.open(ChannelShowMembersDialog, {
+      width: `${DLG_W}px`,
+      height: '411px',
+      autoFocus: false,
+      hasBackdrop: true,
+      panelClass: 'members-dialog-panel',
+      position: { top: `${top}px`, left: `${left}px` },
+    });
 
-  const sub = this.members$.subscribe(ms => {
-    ref.componentInstance.members = ms;
-    ref.componentInstance.currentUserId = this.currentUserId ?? '';
-    ref.componentInstance.channelName = this.channelData?.name ?? '';
-    ref.componentInstance.addIconAnchor = anchor ?? null;
-    sub.unsubscribe();
-  });
+    const sub = this.members$.subscribe((ms) => {
+      ref.componentInstance.members = ms;
+      ref.componentInstance.currentUserId = this.currentUserId ?? '';
+      ref.componentInstance.channelName = this.channelData?.name ?? '';
+      ref.componentInstance.addIconAnchor = anchor ?? null;
+      sub.unsubscribe();
+    });
 
-  ref.componentInstance.close.subscribe(() => ref.close());
-  ref.componentInstance.addMembersClick.subscribe(({ ev, anchor }) => {
-    this.openAddMembersUnderIcon(ev, anchor ?? el);
-  });
-}
+    ref.componentInstance.close.subscribe(() => ref.close());
+    ref.componentInstance.addMembersClick.subscribe(({ ev, anchor }) => {
+      this.openAddMembersUnderIcon(ev, anchor ?? el);
+    });
+  }
 
-  // Öffnet dialog-icon-add-member-to-channel //
+  // open dialog-icon-add-member-to-channel //
   openAddMembersUnderIcon(ev: MouseEvent, anchor: HTMLElement) {
     ev.stopPropagation();
 

--- a/src/app/features/workspace/components/channel-item/channel-item.html
+++ b/src/app/features/workspace/components/channel-item/channel-item.html
@@ -17,5 +17,6 @@
 </svg>
 
     <span class="channel-name">{{ channel.name }}</span>
+    <span class="badge" *ngIf="unread > 0">{{ unread }}</span>
   </li>
 </a>

--- a/src/app/features/workspace/components/channel-item/channel-item.scss
+++ b/src/app/features/workspace/components/channel-item/channel-item.scss
@@ -59,4 +59,28 @@
       fill: #444df2;
     }
   }
+
+  .badge {
+    margin-left: auto;
+    min-width: 22px;
+    height: 22px;
+    border-radius: 50px;
+    background: #e53935; 
+    color: #fff;
+    font-family: 'Nunito', sans-serif;
+    font-size: 12px;
+    line-height: 22px;
+    text-align: center;
+    font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0; 
+    box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
+  }
+
+  &:hover .badge {
+    transform: translateY(-1px);
+    transition: transform 0.15s ease;
+  }
 }

--- a/src/app/features/workspace/components/channel-item/channel-item.ts
+++ b/src/app/features/workspace/components/channel-item/channel-item.ts
@@ -1,16 +1,53 @@
-import { Component, Input, OnInit } from '@angular/core';
+import {
+  Component,
+  Input,
+  OnInit,
+  OnDestroy,
+  OnChanges,
+  SimpleChanges,
+  inject,
+} from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { Subscription } from 'rxjs';
+import { ReadStateService } from '../../../../../services/read-state.service';
 
 @Component({
   selector: 'app-channel-item',
-  imports: [RouterModule],
+  standalone: true,
+  imports: [RouterModule, CommonModule],
   templateUrl: './channel-item.html',
-  styleUrl: './channel-item.scss'
+  styleUrl: './channel-item.scss',
 })
-export class ChannelItem implements OnInit {
+export class ChannelItem implements OnInit, OnDestroy, OnChanges {
   @Input() channel: any;
+  @Input() meUid: string | null = null;
 
+  unread = 0;
+  private sub?: Subscription;
+  private read = inject(ReadStateService);
 
   ngOnInit(): void {
+    this.setupSub();
+  }
+
+  ngOnChanges(_: SimpleChanges): void {
+    this.setupSub();
+  }
+
+  private setupSub() {
+    this.sub?.unsubscribe();
+    if (!this.meUid || !this.channel?.id) {
+      this.unread = 0;
+      return;
+    }
+
+    this.sub = this.read
+      .unreadChannelCount$(this.channel.id, this.meUid)
+      .subscribe((c) => (this.unread = c));
+  }
+
+  ngOnDestroy(): void {
+    this.sub?.unsubscribe();
   }
 }

--- a/src/app/features/workspace/components/contact-item/contact-item.html
+++ b/src/app/features/workspace/components/contact-item/contact-item.html
@@ -7,7 +7,9 @@
   <span class="name">
     {{ user.name }}
     @if (user.uid === meUid) {
-    <span class="you">(Du)</span>
+      <span class="you">(Du)</span>
     }
   </span>
+
+  <span class="badge" *ngIf="unread > 0">{{ unread }}</span>
 </li>

--- a/src/app/features/workspace/components/contact-item/contact-item.scss
+++ b/src/app/features/workspace/components/contact-item/contact-item.scss
@@ -68,4 +68,27 @@
       transition: color 0.2s ease;
     }
   }
+  .badge {
+    margin-left: auto;
+    min-width: 22px;
+    height: 22px;
+    border-radius: 50px;
+    background: #e53935; 
+    color: #fff;
+    font-family: 'Nunito', sans-serif;
+    font-size: 12px;
+    line-height: 22px;
+    text-align: center;
+    font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0; 
+    box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
+  }
+
+  &:hover .badge {
+    transform: translateY(-1px);
+    transition: transform 0.15s ease;
+  }
 }

--- a/src/app/features/workspace/components/contact-item/contact-item.ts
+++ b/src/app/features/workspace/components/contact-item/contact-item.ts
@@ -1,19 +1,40 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, OnInit, OnDestroy, inject } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { Subscription } from 'rxjs';
+import { ReadStateService } from '../../../../../services/read-state.service';
 
 @Component({
   selector: 'app-contact-item',
-  imports: [RouterModule],
+  standalone: true,
+  imports: [RouterModule, CommonModule],
   templateUrl: './contact-item.html',
-  styleUrl: './contact-item.scss'
+  styleUrl: './contact-item.scss',
 })
-export class ContactItem {
+export class ContactItem implements OnInit, OnDestroy {
   @Input() user: any;
   @Input() meUid: string | null = null;
   @Output() contactClick = new EventEmitter<any>();
+
+  unread = 0;
+  private sub?: Subscription;
+  private read = inject(ReadStateService);
+
+  ngOnInit(): void {
+    if (!this.meUid || !this.user?.uid) return;
+    const dmId = this.calculateDmId(this.meUid, this.user.uid);
+    this.sub = this.read.unreadDmCount$(dmId, this.meUid).subscribe((c) => (this.unread = c));
+  }
+
+  ngOnDestroy(): void {
+    this.sub?.unsubscribe();
+  }
 
   onContactClick() {
     this.contactClick.emit(this.user);
   }
 
+  private calculateDmId(a: string, b: string) {
+    return a < b ? `${a}-${b}` : `${b}-${a}`;
+  }
 }

--- a/src/app/features/workspace/components/devspace-sidenav-content/devspace-sidenav-content.html
+++ b/src/app/features/workspace/components/devspace-sidenav-content/devspace-sidenav-content.html
@@ -96,6 +96,7 @@
           </g>
         </svg>
         <h3 id="channels-title-text" class="channels-title-text">Channels</h3>
+        <span class="dm-total-badge" *ngIf="totalUnreadChannels > 0">{{ totalUnreadChannels }}</span>
       </div>
 
       <button
@@ -144,7 +145,7 @@
     <div class="section-content-wrapper">
       <ul class="channel-list" role="list">
         @for (channel of visibleChannels; track channel.id) {
-        <app-channel-item [channel]="channel"></app-channel-item>
+        <app-channel-item [channel]="channel" [meUid]="meUid"></app-channel-item>
         }
       </ul>
 
@@ -248,6 +249,7 @@
         </svg>
 
         <h3 id="dms-heading" class="section-heading">Direktnachrichten</h3>
+         <span class="dm-total-badge" *ngIf="totalUnread > 0">{{ totalUnread }}</span>
       </div>
     </header>
     @if (dmsOpen) {

--- a/src/app/features/workspace/components/devspace-sidenav-content/devspace-sidenav-content.scss
+++ b/src/app/features/workspace/components/devspace-sidenav-content/devspace-sidenav-content.scss
@@ -396,3 +396,21 @@ $radius-pill: 999px;
     background-color: #eceefe;
   }
 }
+
+.dm-total-badge {
+  margin-left: 8px;
+  min-width: 22px;
+  height: 22px;
+  border-radius: 50px;
+  background: #e53935;   
+  color: #fff;
+  font-family: 'Nunito', sans-serif;
+  font-size: 12px;
+  line-height: 22px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
+}

--- a/src/app/features/workspace/components/devspace-sidenav-content/devspace-sidenav-content.ts
+++ b/src/app/features/workspace/components/devspace-sidenav-content/devspace-sidenav-content.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { CommonModule } from '@angular/common';
-import { Observable, Subscription, combineLatest } from 'rxjs';
+import { Observable, Subscription, map, of, combineLatest, firstValueFrom, auditTime } from 'rxjs';
 import { UserService } from '../../../../../services/user.service';
 import { User } from '../../../../../models/user.class';
 import {
@@ -16,7 +16,6 @@ import {
   writeBatch,
 } from '@angular/fire/firestore';
 import { Router, RouterModule } from '@angular/router';
-import { firstValueFrom } from 'rxjs';
 import { AuthService } from '../../../../../services/auth-service';
 import { FormsModule } from '@angular/forms';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
@@ -25,7 +24,7 @@ import { AddUsersToChannel } from '../add-users-to-channel/add-users-to-channel'
 import { ChannelItem } from '../channel-item/channel-item';
 import { ChannelService } from '../../../../../services/channel-service';
 import { ContactItem } from '../contact-item/contact-item';
-import { user } from '@angular/fire/auth';
+import { ReadStateService } from '../../../../../services/read-state.service';
 
 @Component({
   selector: 'app-devspace-sidenav-content',
@@ -45,12 +44,18 @@ import { user } from '@angular/fire/auth';
 })
 export class DevspaceSidenavContent implements OnInit, OnDestroy {
   users: User[] = [];
+  sortedUsers: User[] = [];
   private sub?: Subscription;
   private channelsSub?: Subscription;
+  private sortSub?: Subscription;
+  private totalUnreadSub?: Subscription;
+  private totalUnreadChannelsSub?: Subscription;
 
   dmsOpen = true;
   channelsOpen = true;
   currentChatId: string = '';
+  totalUnread = 0;
+  totalUnreadChannels = 0;
 
   // Users//
 
@@ -73,7 +78,8 @@ export class DevspaceSidenavContent implements OnInit, OnDestroy {
     private router: Router,
     private authService: AuthService,
     private dialog: MatDialog,
-    private channelService: ChannelService
+    private channelService: ChannelService,
+    private read: ReadStateService
   ) {}
 
   ngOnInit(): void {
@@ -88,8 +94,117 @@ export class DevspaceSidenavContent implements OnInit, OnDestroy {
     ]).subscribe(([list, me]) => {
       this.meUid = me?.uid ?? null;
       this.updateUserList(list);
+      this.buildSortedUsers(list, this.meUid);
+      this.buildTotalUnread(list, this.meUid);
+
+      this.buildTotalUnreadChannels(this.channels, this.meUid);
     });
   }
+
+  // total count for channels //
+  private buildTotalUnreadChannels(channels: any[], meUid: string | null) {
+    this.totalUnreadChannelsSub?.unsubscribe();
+    if (!meUid) {
+      this.totalUnreadChannels = 0;
+      return;
+    }
+
+    const myChannels = (channels ?? []).filter((c) =>
+      c?.members?.some((m: any) => (typeof m === 'string' ? m : m?.uid) === meUid)
+    );
+    if (!myChannels.length) {
+      this.totalUnreadChannels = 0;
+      return;
+    }
+
+    const streams = myChannels.map((c) => this.read.unreadChannelCount$(c.id, meUid));
+    this.totalUnreadChannelsSub = combineLatest(streams)
+      .pipe(map((arr) => arr.reduce((s, n) => s + (n || 0), 0)))
+      .subscribe((sum) => (this.totalUnreadChannels = sum));
+  }
+  // total count for channels //
+  
+  // for total cound by Direkt messasges //
+  private buildTotalUnread(list: User[], meUid: string | null) {
+    this.totalUnreadSub?.unsubscribe();
+
+    if (!meUid) {
+      this.totalUnread = 0;
+      return;
+    }
+
+    const others = list.filter((u) => u.uid !== meUid);
+    if (!others.length) {
+      this.totalUnread = 0;
+      return;
+    }
+
+    const streams = others.map((u) => {
+      const dmId = this.calculateDmId(u);
+      return this.read.unreadDmCount$(dmId, meUid);
+    });
+
+    this.totalUnreadSub = combineLatest(streams)
+      .pipe(
+        map((arr) => arr.reduce((sum, n) => sum + (n || 0), 0)),
+        auditTime(16)
+      )
+      .subscribe((sum) => (this.totalUnread = sum));
+  }
+  // for total cound by Direkt messasges //
+
+  // for sorting by unread messages //
+  private buildSortedUsers(list: User[], meUid: string | null) {
+    this.sortSub?.unsubscribe();
+
+    if (!meUid) {
+      this.sortedUsers = list;
+      return;
+    }
+
+    const myId = meUid as string;
+
+    const me = list.find((u) => u.uid === myId) || null;
+    const others = list.filter((u) => u.uid !== myId);
+
+    if (!others.length) {
+      this.sortedUsers = me ? [me] : [];
+      return;
+    }
+
+    const metaStreams = others.map((u) => {
+      const dmId = this.calculateDmId(u);
+      return this.read.dmMeta$(dmId, myId).pipe(map((meta) => ({ uid: u.uid, meta })));
+    });
+
+    this.sortSub = combineLatest(metaStreams)
+      .pipe(auditTime(16))
+      .subscribe((metaArr) => {
+        const metaMap = new Map(metaArr.map((x) => [x.uid, x.meta]));
+
+        const sortedOthers = [...others].sort((a, b) => {
+          const ma = metaMap.get(a.uid) || { unread: 0, lastMessageAt: 0 };
+          const mb = metaMap.get(b.uid) || { unread: 0, lastMessageAt: 0 };
+
+          const aHas = ma.unread > 0 ? 1 : 0;
+          const bHas = mb.unread > 0 ? 1 : 0;
+          if (aHas !== bHas) return bHas - aHas;
+
+          if (ma.lastMessageAt !== mb.lastMessageAt) return mb.lastMessageAt - ma.lastMessageAt;
+
+          const nameCmp = String(a.name ?? '').localeCompare(String(b.name ?? ''), undefined, {
+            sensitivity: 'base',
+          });
+          if (nameCmp !== 0) return nameCmp;
+
+          return String(a.uid).localeCompare(String(b.uid));
+        });
+
+        this.sortedUsers = me ? [me, ...sortedOthers] : sortedOthers;
+        this.maxVisible = Math.min(this.maxVisible, this.sortedUsers.length);
+      });
+  }
+  // for sorting by unread messages //
 
   private updateUserList(list: any[]): void {
     if (this.meUid) {
@@ -110,6 +225,7 @@ export class DevspaceSidenavContent implements OnInit, OnDestroy {
     ]).subscribe(([channels, user]) => {
       const userChannels = this.filterUserChannels(channels, user?.uid);
       this.channels = this.sortChannels(userChannels);
+      this.buildTotalUnreadChannels(this.channels, this.meUid);
     });
   }
 
@@ -131,10 +247,14 @@ export class DevspaceSidenavContent implements OnInit, OnDestroy {
     this.sub?.unsubscribe();
     this.channelsSub?.unsubscribe();
     this.currentUserSub?.unsubscribe();
+    this.sortSub?.unsubscribe();
+    this.totalUnreadSub?.unsubscribe();
+    this.totalUnreadChannelsSub?.unsubscribe();
   }
 
   get visibleUsers(): User[] {
-    return this.users.slice(0, Math.min(this.maxVisible, this.users.length));
+    const base = this.sortedUsers.length ? this.sortedUsers : this.users;
+    return base.slice(0, Math.min(this.maxVisible, base.length));
   }
 
   get visibleChannels() {

--- a/src/app/features/workspace/components/dm-interface-content/dm-interface-content.ts
+++ b/src/app/features/workspace/components/dm-interface-content/dm-interface-content.ts
@@ -9,7 +9,7 @@ import { MessageBubbleComponent } from '../../../../shared/components/message-bu
 import { BaseChatInterfaceComponent } from '../base-chat-interface-component/base-chat-interface-component';
 import { MatDialog } from '@angular/material/dialog';
 import { DialogUserCardComponent } from '../../../../shared/components/dialog-user-card/dialog-user-card.component';
-
+import { ReadStateService } from '../../../../../services/read-state.service';
 
 @Component({
   selector: 'app-dm-interface-content',
@@ -39,19 +39,41 @@ export class DmInterfaceContent extends BaseChatInterfaceComponent {
     protected override route: ActivatedRoute,
     protected override firestore: Firestore,
     protected override authService: AuthService,
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    private read: ReadStateService
   ) {
     super(route, firestore, authService);
   }
 
-  /**
-   * React to route changes: when the DM chatId changes, (re)load the recipient's profile.
-   * @param chatId The current DM document id (usually composed of two user ids, e.g. "uidA-uidB").
-   */
   override onChatIdChanged(chatId: string): void {
     this.loadRecipientData(chatId);
+
+    if (this.currentUserId) {
+      this.read.markDmRead(chatId, this.currentUserId);
+    } else {
+      const sub = this.authService.currentUser$.subscribe((u) => {
+        if (u?.uid) {
+          this.read.markDmRead(chatId, u.uid);
+          sub.unsubscribe();
+        }
+      });
+    }
   }
 
+  // for the message count //
+  override async handleNewMessage(text: string) {
+    if (!this.chatId) return;
+
+    this.read.bumpLastMessage(this.chatId);
+
+    await super.handleNewMessage(text);
+
+    if (this.currentUserId) {
+      await this.read.markDmRead(this.chatId, this.currentUserId);
+    }
+  }
+  // for the message count //
+  
   /**
    * Load the DM recipient's profile for the given chat.
    * - Determines if this is a self-DM (user messages themselves).

--- a/src/services/read-state.service.ts
+++ b/src/services/read-state.service.ts
@@ -1,0 +1,167 @@
+import { Injectable, inject } from '@angular/core';
+import {
+  Firestore,
+  doc,
+  setDoc,
+  serverTimestamp,
+  docData,
+  collection,
+  query,
+  where,
+  orderBy,
+  Timestamp,
+  CollectionReference,
+  collectionData,
+  limit,
+} from '@angular/fire/firestore';
+import { BehaviorSubject, Observable, combineLatest, map, switchMap } from 'rxjs';
+
+type ReadDoc = { lastReadAt?: Timestamp } | undefined;
+
+@Injectable({ providedIn: 'root' })
+export class ReadStateService {
+  private firestore = inject(Firestore);
+
+  private optim$ = new Map<string, BehaviorSubject<Timestamp>>();
+
+  private key(dmId: string, uid: string) {
+    return `${dmId}|${uid}`;
+  }
+
+  private getOptimistic$(dmId: string, uid: string) {
+    const k = this.key(dmId, uid);
+    if (!this.optim$.has(k))
+      this.optim$.set(k, new BehaviorSubject<Timestamp>(Timestamp.fromMillis(0)));
+    return this.optim$.get(k)!;
+  }
+
+  private bumpMap = new Map<string, BehaviorSubject<number>>();
+  private getLastBump$(dmId: string) {
+    if (!this.bumpMap.has(dmId)) this.bumpMap.set(dmId, new BehaviorSubject<number>(0));
+    return this.bumpMap.get(dmId)!;
+  }
+
+  bumpLastMessage(dmId: string) {
+    this.getLastBump$(dmId).next(Date.now());
+  }
+
+  readDoc(dmId: string, uid: string) {
+    return doc(this.firestore, `dms/${dmId}/reads/${uid}`);
+  }
+
+  async markDmRead(dmId: string, uid: string) {
+    // 1) sofort lokal auf "jetzt" setzen (verhindert Blink)
+    this.getOptimistic$(dmId, uid).next(Timestamp.now());
+    // 2) Firestore persistieren
+    const ref = this.readDoc(dmId, uid);
+    await setDoc(ref, { lastReadAt: serverTimestamp() }, { merge: true });
+  }
+
+  unreadDmCount$(dmId: string, uid: string): Observable<number> {
+    const myReadRef = this.readDoc(dmId, uid);
+    const fs$ = docData(myReadRef) as Observable<ReadDoc>;
+    const opt$ = this.getOptimistic$(dmId, uid);
+
+    return combineLatest([fs$, opt$]).pipe(
+      switchMap(([read, opt]) => {
+        // since = max(Firestore, Optimistic)
+        const fsSince =
+          read?.lastReadAt instanceof Timestamp ? read.lastReadAt : Timestamp.fromMillis(0);
+        const since = fsSince.toMillis() > opt.toMillis() ? fsSince : opt;
+
+        const messagesRef = collection(
+          this.firestore,
+          `dms/${dmId}/messages`
+        ) as CollectionReference<any>;
+        const q = query(messagesRef, where('timestamp', '>', since), orderBy('timestamp', 'asc'));
+        return collectionData(q, { idField: 'id' }) as Observable<any[]>;
+      }),
+      map((msgs) => msgs.filter((m) => m?.authorId !== uid).length)
+    );
+  }
+
+  /** Firestore-basierter letzter Nachrichtenzeitpunkt (Millis) */
+  private lastMessageAtFs$(dmId: string): Observable<number> {
+    const messagesRef = collection(
+      this.firestore,
+      `dms/${dmId}/messages`
+    ) as CollectionReference<any>;
+
+    // neueste Nachricht holen (1 Stück)
+    const qy = query(messagesRef, orderBy('timestamp', 'desc'), limit(1));
+
+    return collectionData(qy).pipe(
+      map((rows: any[]) => {
+        const ts = rows?.[0]?.timestamp;
+        return ts instanceof Timestamp ? ts.toMillis() : 0;
+      })
+    );
+  }
+
+  // Kombi-Meta für Sortierung
+  lastMessageAt$(dmId: string): Observable<number> {
+    return combineLatest([this.lastMessageAtFs$(dmId), this.getLastBump$(dmId)]).pipe(
+      map(([fsMillis, bumpMillis]) => Math.max(fsMillis, bumpMillis))
+    );
+  }
+
+  dmMeta$(dmId: string, uid: string): Observable<{ unread: number; lastMessageAt: number }> {
+    return combineLatest([this.unreadDmCount$(dmId, uid), this.lastMessageAt$(dmId)]).pipe(
+      map(([unread, lastMessageAt]) => ({ unread, lastMessageAt }))
+    );
+  }
+
+  private msgsRef(kind: 'dms'|'channels', id: string) {
+  return collection(this.firestore, `${kind}/${id}/messages`) as CollectionReference<any>;
+}
+private readDocGeneric(kind: 'dms'|'channels', id: string, uid: string) {
+  return doc(this.firestore, `${kind}/${id}/reads/${uid}`);
+}
+
+// ---- CHANNEL: Read markieren ----
+markChannelRead(channelId: string, uid: string) {
+  // optimistisch (gegen Blink)
+  this.getOptimistic$(channelId, uid).next(Timestamp.now());
+  const ref = this.readDocGeneric('channels', channelId, uid);
+  return setDoc(ref, { lastReadAt: serverTimestamp() }, { merge: true });
+}
+
+// ---- CHANNEL: Unread zählen ----
+unreadChannelCount$(channelId: string, uid: string): Observable<number> {
+  const fs$ = docData(this.readDocGeneric('channels', channelId, uid)) as Observable<ReadDoc>;
+  const opt$ = this.getOptimistic$(channelId, uid);
+  return combineLatest([fs$, opt$]).pipe(
+    switchMap(([read, opt]) => {
+      const fsSince = read?.lastReadAt instanceof Timestamp ? read.lastReadAt : Timestamp.fromMillis(0);
+      const since = fsSince.toMillis() > opt.toMillis() ? fsSince : opt;
+      const qy = query(this.msgsRef('channels', channelId), where('timestamp','>',since), orderBy('timestamp','asc'));
+      return collectionData(qy) as Observable<any[]>;
+    }),
+    map(msgs => msgs.filter(m => m?.authorId !== uid).length)
+  );
+}
+
+// ---- CHANNEL: letzte Nachricht (optimistisch) ----
+bumpLastChannelMessage(channelId: string) {
+  this.getLastBump$(channelId).next(Date.now());
+}
+private lastChannelMessageAtFs$(channelId: string): Observable<number> {
+  const qy = query(this.msgsRef('channels', channelId), orderBy('timestamp','desc'), limit(1));
+  return collectionData(qy).pipe(map((rows:any[]) => {
+    const ts = rows?.[0]?.timestamp;
+    return ts instanceof Timestamp ? ts.toMillis() : 0;
+  }));
+}
+lastChannelMessageAt$(channelId: string): Observable<number> {
+  return combineLatest([ this.lastChannelMessageAtFs$(channelId), this.getLastBump$(channelId) ])
+    .pipe(map(([fsMillis,bump]) => Math.max(fsMillis, bump)));
+}
+
+// ---- CHANNEL: Kombi-Meta (für Sortierung) ----
+channelMeta$(channelId: string, uid: string): Observable<{ unread: number; lastMessageAt: number }> {
+  return combineLatest([
+    this.unreadChannelCount$(channelId, uid),
+    this.lastChannelMessageAt$(channelId),
+  ]).pipe(map(([unread, lastMessageAt]) => ({ unread, lastMessageAt })));
+}
+}


### PR DESCRIPTION
1) To the right of the contact item, you now have the count of unread messages, just like with channels.

2) We also have a total count for the entire channels and direct messages area.

3) Direct messages are now organized according to how contacts write to each other, with those containing a count appearing at the top.